### PR TITLE
Fix arm64 windows build error by skipping strip command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,10 +44,19 @@ set(clangd-executable
     ${CMAKE_BINARY_DIR}/llvm/${config-subfolder}/bin/clangd${CMAKE_EXECUTABLE_SUFFIX}
 )
 
+set(IS_ARM64_WINDOWS FALSE)
+
+if((CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows") AND
+   (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "ARM64"))
+  set(IS_ARM64_WINDOWS TRUE)
+  message(STATUS "Building for ARM64 Windows")
+endif()
+
 # Reduce the size of the executable by executing strip if it is present on the
 # system
 find_program(STRIP_EXECUTABLE strip)
-if(STRIP_EXECUTABLE)
+if(STRIP_EXECUTABLE AND NOT IS_ARM64_WINDOWS)
+  message(STATUS "Stripping clangd executable")
   add_custom_target(
     strip-clangd ALL
     COMMAND ${STRIP_EXECUTABLE} ${clangd-executable}

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ clangd
 |----------|---------|--------------|-------------------------------------|
 | Ubuntu   | 24.04   | x86_64       | manylinux                           |
 | Ubuntu   | 24.04   | x86_64       | [musllinux](https://musl.libc.org/) |
-| Ubuntu   | 24.04   | ARM64        | manylinux                           |
-| Ubuntu   | 24.04   | ARM64        | [musllinux](https://musl.libc.org/) |         
-| macOS    | 15      | ARM64        |                                     |
+| Ubuntu   | 24.04   | arm64        | manylinux                           |
+| Ubuntu   | 24.04   | arm64        | [musllinux](https://musl.libc.org/) |         
+| macOS    | 15      | arm64        |                                     |
 | macOS    | 13      | x86_64       |                                     |
 | Windows  | 2025    | x86_64       |                                     |
-| Windows  | 11      | ARM64        |                                     |
+| Windows  | 11      | arm64        |                                     |


### PR DESCRIPTION
Strip command does not work on arm64 PE executables apparently